### PR TITLE
Handle missing query string parameters in heuristic

### DIFF
--- a/heuristic.js
+++ b/heuristic.js
@@ -60,11 +60,18 @@ function rate(entryRequest, request) {
     var requestQuery = request.parsedUrl.query;
     if (entryQuery && requestQuery) {
         for (name in requestQuery) {
-            if (entryQuery[name]) {
+            if (entryQuery[name] === undefined) {
+                points -= 0.5;
+            } else {
                 points += stripProtocol(entryQuery[name]) === stripProtocol(requestQuery[name]) ? 1 : 0;
             }
         }
-        // TODO handle missing query parameters and adjust score appropriately
+
+        for (name in entryQuery) {
+            if (requestQuery[name] === undefined) {
+                points -= 0.5;
+            }
+        }
     }
 
     // each header


### PR DESCRIPTION
Howdy! First off, thanks for releasing this - it was super useful for me in debugging an issue that would have otherwise been very painful to figure out.

In my particular use case, I had a .har file with lots of requests that had the same path, but different sets of query string parameters, and the heuristic wasn't working very well for matching up those requests because some of the _values_ of the query string parameters were different between the incoming requests and the .har file entries, but the set of keys (that is, the _names_ of the query string parameters) were matching.

This tweak the the heuristic made it work better for my use case, and I'm guessing it'd be a net positive or neutral change for most other usages as well.

If you'd rather see this handled in a different way, just let me know what you're thinking and I'd be happy to give it a try.

Thanks!
