### PR TITLE
[fix] Check arg is string in stripProtocol func

### DIFF
--- a/heuristic.js
+++ b/heuristic.js
@@ -88,7 +88,11 @@ function rate(entryRequest, request) {
 }
 
 function stripProtocol(string) {
-    return string.replace(/^https?/, "");
+    if (typeof string === "string") {
+        return string.replace(/^https?/, "");
+    } else {
+        return string;
+    }
 }
 
 function indexHeaders(entryHeaders) {


### PR DESCRIPTION
Hey I found the server-replay crashing for a particular har file and it was due to an array being passed into the stripProtocol function

My change seemed to resolve the issue.

Cheers
