### PR TITLE
Change heuristic to prefer entries that haven't been returned yet

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,13 +37,15 @@ function makeRequestListener(entries, options) {
     // for mocking
     var fs = options.fs || _fs;
 
+    var heuristicGusser = heuristic.makeHeuristicGuesser(entries);
+
     return function (request, response) {
         if (debug) {
             console.log(request.method, request.url);
         }
         request.parsedUrl = URL.parse(request.url, true);
 
-        var entry = heuristic(entries, request);
+        var entry = heuristicGusser.bestEntryForRequest(request);
 
         var localPath;
         for (var i = 0; i < config.mappings.length; i++) {


### PR DESCRIPTION
This change alters the heuristic to prefer HAR entries that have not yet been returned (to improve accuracy in record-replay style scenarios).  The change also has some refactoring to store the returned/unreturned state non-globally